### PR TITLE
Enable PR builder

### DIFF
--- a/.github/workflows/prbuilder.yml
+++ b/.github/workflows/prbuilder.yml
@@ -1,0 +1,29 @@
+name: PR Builder 
+
+on:
+  pull_request:
+    branches: master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [2.7]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+    - name: Test with pytest
+      run: |
+        pip install pytest pipenv
+        pipenv install --system --deploy --dev
+        make test


### PR DESCRIPTION
This PR enabled Github action based PR builder.
This runs on every PR raised against master
Tests run on python2.7
install dependencies and run the python tests
Update the PR with test status