### PR TITLE
Events: get spot price from bid-advisor

### DIFF
--- a/cloud_provider/aws/aws_minion_manager.py
+++ b/cloud_provider/aws/aws_minion_manager.py
@@ -217,10 +217,7 @@ class AWSMinionManager(MinionManagerBase):
         try:
             asg_tag = asg_meta.get_mm_tag()
             bid_info = asg_meta.get_bid_info()
-            if not bid_info.get("price"):
-                current_price = self.get_new_bid_info(asg_meta).get("price") or ""
-            else:
-                current_price = bid_info.get("price")
+            current_price = self.get_new_bid_info(asg_meta).get("price") or ""
 
             if asg_tag == "no-spot":
                 if bid_info["type"] == "spot":


### PR DESCRIPTION
Fixes https://github.com/keikoproj/minion-manager/issues/71

We will get the latest price from bid-advisor to avoid stale ASG spot price,

#### Problem: 
When we are already running spot, if we switch instance type on ASG the events are still getting old instance type spot price 

#### Before: ( Switch m5.xl to m5.2xl )
```
13m         Normal   SpotRecommendationGiven   spotpriceinfo/eks-vgu-k8s-instance-manager-nodes   {"apiVersion":"v1alpha1","spotPrice":"0.192", "useSpot": true}
8m          Normal   SpotRecommendationGiven   spotpriceinfo/eks-vgu-k8s-instance-manager-nodes   {"apiVersion":"v1alpha1","spotPrice":"0.192", "useSpot": true}
2m59s       Normal   SpotRecommendationGiven   spotpriceinfo/eks-vgu-k8s-instance-manager-nodes   {"apiVersion":"v1alpha1","spotPrice":"0.192", "useSpot": true}
```

#### After this change: ( Switch m5.xl to m5.2xl )
```
11m         Normal   SpotRecommendationGiven    spotpriceinfo/eks-vgu-k8s-instance-manager-nodes  {"apiVersion":"v1alpha1","spotPrice":"0.192", "useSpot": true}
5m6s        Normal   SpotRecommendationGiven    spotpriceinfo/eks-vgu-k8s-instance-manager-nodes  {"apiVersion":"v1alpha1","spotPrice":"0.384", "useSpot": true}
5s          Normal   SpotRecommendationGiven    spotpriceinfo/eks-vgu-k8s-instance-manager-nodes  {"apiVersion":"v1alpha1","spotPrice":"0.384", "useSpot": true}
```

#### Testing without EventOnly Mode:
- unit-tests
- Verified that switching from on-demand to spot instances work as expected.
- Verified that switching from spot to on-demand instances work as expected.
