### PR TITLE
Remove validate_usr_args()

### DIFF
--- a/minion_manager.py
+++ b/minion_manager.py
@@ -15,26 +15,14 @@ logging.basicConfig(format="%(asctime)s %(levelname)s %(name)s " +
                     stream=sys.stdout, level=logging.INFO)
 
 
-def validate_usr_args(usr_args):
-    """
-    Validates the arguments provided by the user.
-    """
-    assert usr_args.cloud.lower() == "aws", "Only AWS is currently supported."
-    assert usr_args.cluster_name is not None, "Cluster name is required"
-    if "profile" not in usr_args:
-        usr_args.profile = None
-
-
 def run():
+    """Parses user provided arguments and validates them.
+    Asserts if any of the provided arguments is incorrect.
     """
-    Parses user provided arguments and validates them. Asserts if any of
-    the provided arguments is incorrect.
-    """
-    parser = argparse.ArgumentParser(description="Manage the minions in a " +
-                                     "K8S cluster")
+    parser = argparse.ArgumentParser(description="Manage the minions in a K8S cluster")
     parser.add_argument("--region", help="Region in which the cluster exists",
                         required=True)
-    parser.add_argument("--cloud", default="aws",
+    parser.add_argument("--cloud", default="aws", choices=['aws'], type=str.lower,
                         help="Cloud provider (only AWS as of now)")
     parser.add_argument("--profile", help="Credentials profile to use")
     parser.add_argument("--refresh-interval-seconds", default="300",
@@ -45,11 +33,11 @@ def run():
                         help="Whether minion-manager should only emit events and *not* actually do spot/on-demand changes to launch-config")
 
     usr_args = parser.parse_args()
-    validate_usr_args(usr_args)
 
-    logger.info("Starting minion-manager for cluster: %s, in region " +
-                "%s for cloud provider %s", usr_args.cluster_name,
-                usr_args.region, usr_args.cloud)
+    logger.info("Starting minion-manager for cluster: %s, in region %s for cloud provider %s",
+                usr_args.cluster_name,
+                usr_args.region,
+                usr_args.cloud)
 
     if usr_args.cloud == "aws":
         minion_manager = Broker.get_impl_object(


### PR DESCRIPTION
* `validate_usr_args()` had a couple of statements that did nothing since `argparse` already do something similar to those statements internally as the parser is constructed and ran. For checking `usr_args.cloud.lower() == "aws"`, it was more pythonic to leverage argparse's built-in methods to check if the input was valid.
* Minor PEP 8 or pythonic changes