### PR TITLE
Skip ASG using LaunchTemplate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN pip install pipenv==2018.10.13
 WORKDIR /src
 COPY Pipfile /src/
 COPY Pipfile.lock /src/
-COPY binaries/kubectl-v1.12.3-linux-amd64 /usr/local/bin/kubectl
+RUN wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.18.16/bin/linux/amd64/kubectl
+RUN chmod +x /usr/local/bin/kubectl
 
 # This will be used as Main Image
 FROM Base AS Main
@@ -19,4 +20,3 @@ FROM Base AS Dev
 
 RUN apk add --no-cache build-base openssl-dev libffi-dev 
 RUN pipenv install --system --deploy --dev
-#COPY . /src    

--- a/cloud_provider/aws/aws_minion_manager.py
+++ b/cloud_provider/aws/aws_minion_manager.py
@@ -109,6 +109,10 @@ class AWSMinionManager(MinionManagerBase):
         resp = ac_client.describe_auto_scaling_groups(MaxRecords=100)
         for r in resp["AutoScalingGroups"]:
             is_candidate = False
+            # skipping if ASG is using LaunchTemplate as it is not supported
+            if not r.get("LaunchConfigurationName"):
+                logger.warn("Skipping: asg %s is using LaunchTemplate", r.get("AutoScalingGroupName"))
+                continue
             # Scan for KubernetesCluster name. If the value matches the cluster_name
             # provided in the input, set 'is_candidate'.
             for tag in r['Tags']:


### PR DESCRIPTION
Fixes #77 
skipping if ASG is using LaunchTemplate as it is not supported

### Testing

```
2021-03-18T04:29:19 WARNING aws_minion_manager MainThread: Skipping: asg test-nodes is using LaunchTemplate
```
